### PR TITLE
ci: fix clippy version to before 2022-03-14

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2022-03-13
           override: true
           components: clippy
       - uses: actions/checkout@v2


### PR DESCRIPTION
See https://github.com/rust-lang/rust-clippy/issues/8629