### PR TITLE
Fix bug in Python linked list cycle detection

### DIFF
--- a/python/leetcode_142.py
+++ b/python/leetcode_142.py
@@ -4,6 +4,9 @@
 #         self.val = x
 #         self.next = None
 
+from typing import Optional
+
+
 class Solution:
     def detectCycle(self, head: Optional[ListNode]) -> Optional[ListNode]:
         slow = head
@@ -17,4 +20,4 @@ class Solution:
                     fast = fast.next
                     slow = slow.next
                 return slow
-        return Non
+        return None


### PR DESCRIPTION
## Summary
- add missing Optional import for `detectCycle`
- fix typo returning None

## Testing
- `cargo test --quiet` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_683fccb2ba8c832cb752d3c6abc85d3a