### PR TITLE
Remove example tests for LeetCode 958

### DIFF
--- a/src/leetcode/algorithm_958/mod.rs
+++ b/src/leetcode/algorithm_958/mod.rs
@@ -32,3 +32,17 @@ impl Solution {
         true
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::leetcode::common::TreeNode;
+    use test_case::test_case;
+
+    #[test_case(vec!["1", "2", "3", "4", "5", "6", "7"] => true; "full tree")]
+    #[test_case(vec!["1", "2", "3", "4", "null", "6", "7"] => false; "missing right before left")]
+    fn test_solution(preorder: Vec<&str>) -> bool {
+        let root = TreeNode::from_preorder_str(preorder);
+        Solution::is_complete_tree(root)
+    }
+}


### PR DESCRIPTION
## Summary
- cut duplicate `example` test cases from the completeness check tests
- keep the `full tree` and `missing right before left` scenarios

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683fd92438cc832cafff742b9eda2a19