### PR TITLE
Add test for leetcode 652

### DIFF
--- a/src/leetcode/algorithm_652/mod.rs
+++ b/src/leetcode/algorithm_652/mod.rs
@@ -43,3 +43,23 @@ impl Solution {
         duplicated
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::leetcode::common::TreeNode;
+    use test_case::test_case;
+
+    #[test_case(vec!["1", "2", "3", "4", "null", "2", "4", "null", "null", "4"] => vec![vec![2, 4], vec![4]]; "example 1")]
+    #[test_case(vec!["2", "1", "1"] => vec![vec![1]]; "example 2")]
+    #[test_case(vec!["2", "2", "2", "3", "null", "3", "null"] => vec![vec![2, 3], vec![3]]; "example 3")]
+    fn test_solution(preorder: Vec<&str>) -> Vec<Vec<i32>> {
+        let root = TreeNode::from_preorder_str(preorder);
+        let mut values = Solution::find_duplicate_subtrees(root)
+            .into_iter()
+            .map(TreeNode::serialize)
+            .collect::<Vec<_>>();
+        values.sort();
+        values
+    }
+}

--- a/src/leetcode/common.rs
+++ b/src/leetcode/common.rs
@@ -116,4 +116,25 @@ impl TreeNode {
     pub fn from_preorder_str(elements: Vec<&str>) -> Option<Rc<RefCell<TreeNode>>> {
         Self::from_preorder(parse_input(elements))
     }
+
+    pub fn serialize(root: Option<Rc<RefCell<TreeNode>>>) -> Vec<i32> {
+        let mut values = Vec::new();
+        let mut queue = VecDeque::new();
+        if let Some(node) = root {
+            queue.push_back(node);
+        } else {
+            return values;
+        }
+        while let Some(node) = queue.pop_front() {
+            let node_ref = node.borrow();
+            values.push(node_ref.val);
+            if let Some(left) = node_ref.left.clone() {
+                queue.push_back(left);
+            }
+            if let Some(right) = node_ref.right.clone() {
+                queue.push_back(right);
+            }
+        }
+        values
+    }
 }


### PR DESCRIPTION
## Summary
- add unit test for `leetcode/652` to verify find_duplicate_subtrees
- add two extra test cases
- rename case names and check returned subtree structure
- move serialize helper into `TreeNode` and refactor tests

## Testing
- `cargo test -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_68404fc947d8832c91c88fbc23e26153