### PR TITLE
Fix clippy suggestion

### DIFF
--- a/src/leetcode/algorithm_46/mod.rs
+++ b/src/leetcode/algorithm_46/mod.rs
@@ -14,9 +14,9 @@ mod tests {
         let answer = back_trace::Solution::permute(nums);
         let actual_length = answer.len();
         assert_eq!(
-            right_length, actual_length,
-            "expected length to be {}, got {}, elements are: {:?}",
-            right_length, actual_length, answer
+            right_length,
+            actual_length,
+            "expected length to be {right_length}, got {actual_length}, elements are: {answer:?}"
         );
         let right_answer: HashSet<Vec<i32>> = HashSet::from_iter(right_answer);
         assert_eq!(right_answer, HashSet::from_iter(answer.into_iter()));


### PR DESCRIPTION
## Summary
- fix uninlined-format-args lint in permutation tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685fb97ba1c4832ca822a4f9c17e0172